### PR TITLE
Turn on Tier 2 during PGO (if the Tier 2 box is checked)

### DIFF
--- a/bench_runner/templates/_benchmark.src.yml
+++ b/bench_runner/templates/_benchmark.src.yml
@@ -290,6 +290,10 @@ jobs:
         if: ${{ steps.should_run.outputs.should_run != 'false' }}
         run: |
           echo "PKG_CONFIG_PATH=$(brew --prefix openssl@1.1)/lib/pkgconfig" >> $GITHUB_ENV
+      - name: Enable Tier 2
+        if: ${{ inputs.tier2 }}
+        run: |
+          echo "PYTHON_UOPS=1" >> "$GITHUB_ENV"
       - name: Build Python
         if: ${{ steps.should_run.outputs.should_run != 'false' }}
         run: |
@@ -302,10 +306,6 @@ jobs:
         if: ${{ steps.should_run.outputs.should_run != 'false' }}
         run: |
           venv/bin/python -m pip install --no-binary :all: ./pyperformance
-      - name: Enable Tier 2
-        if: ${{ inputs.tier2 }}
-        run: |
-          echo "PYTHON_UOPS=1" >> "$GITHUB_ENV"
       - name: Running pyperformance
         if: ${{ steps.should_run.outputs.should_run != 'false' }}
         run: |

--- a/bench_runner/templates/_benchmark.src.yml
+++ b/bench_runner/templates/_benchmark.src.yml
@@ -113,6 +113,10 @@ jobs:
           repository: python/pyperformance
           path: pyperformance
           ref: ${{ env.PYPERFORMANCE_HASH }}
+      - name: Enable Tier 2
+        if: ${{ inputs.tier2 }}
+        run: |
+          echo "PYTHON_UOPS=1" >> $env:GITHUB_ENV
       - name: Build Python
         if: ${{ steps.should_run.outputs.should_run != 'false' }}
         run: |
@@ -124,10 +128,6 @@ jobs:
         if: ${{ steps.should_run.outputs.should_run != 'false' }}
         run: |
           venv\Scripts\python.exe -m pip install --no-binary :all: .\pyperformance
-      - name: Enable Tier 2
-        if: ${{ inputs.tier2 }}
-        run: |
-          echo "PYTHON_UOPS=1" >> $env:GITHUB_ENV
       - name: Running pyperformance
         if: ${{ steps.should_run.outputs.should_run != 'false' }}
         run: |
@@ -194,6 +194,10 @@ jobs:
           repository: python/pyperformance
           path: pyperformance
           ref: ${{ env.PYPERFORMANCE_HASH }}
+      - name: Enable Tier 2
+        if: ${{ inputs.tier2 }}
+        run: |
+          echo "PYTHON_UOPS=1" >> "$GITHUB_ENV"
       - name: Build Python
         if: ${{ steps.should_run.outputs.should_run != 'false' }}
         run: |
@@ -212,10 +216,6 @@ jobs:
         if: ${{ steps.should_run.outputs.should_run != 'false' && inputs.perf }}
         run: |
           sudo bash -c "echo 100000 > /proc/sys/kernel/perf_event_max_sample_rate"
-      - name: Enable Tier 2
-        if: ${{ inputs.tier2 }}
-        run: |
-          echo "PYTHON_UOPS=1" >> "$GITHUB_ENV"
       - name: Running pyperformance
         if: ${{ steps.should_run.outputs.should_run != 'false' }}
         run: |


### PR DESCRIPTION
I confirmed that this has an effect, i.e. the test run during PGO data collection isn't ignoring the PYTHON_UOPS environment variable.