### PR TITLE
gh-223: Fix installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Add bench_runner to your `requirements.txt`.  Since there are no PyPI releases (
 git+https://github.com/faster-cpython/bench_runner@{VERSION}#egg=bench_runner
 ```
 
+Replace the {VERSION} above with the latest version tag of `bench_runner`.
+
 Create a virtual environment and install your requirements to it, for example:
 
 ```bash session

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Create a new empty repository on Github and clone it locally.
 Add bench_runner to your `requirements.txt`.  Since there are no PyPI releases (yet), you can install it from a tag in the git repo:
 
 ```text
-git+https://github.com/faster-cpython/bench_runner@v0.2.2#egg=bench_runner
+git+https://github.com/faster-cpython/bench_runner@v0.25.0#egg=bench_runner
 ```
 
 Create a virtual environment and install your requirements to it, for example:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Create a new empty repository on Github and clone it locally.
 Add bench_runner to your `requirements.txt`.  Since there are no PyPI releases (yet), you can install it from a tag in the git repo:
 
 ```text
-git+https://github.com/faster-cpython/bench_runner@v0.25.0#egg=bench_runner
+git+https://github.com/faster-cpython/bench_runner@{VERSION}#egg=bench_runner
 ```
 
 Create a virtual environment and install your requirements to it, for example:


### PR DESCRIPTION
The version at `v0.2.2` doesn't have a `__main__.py`. Running `python -m bench_runner install` fails with

```
No module named bench_runner.__main__; 'bench_runner' is a package and cannot be directly executed
```

`v0.25.0` works

Fixes gh-223.