### PR TITLE
gh-225: Raise a more helpful error in `get_runners` when there are no runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,20 +24,6 @@ source venv/bin/activate
 python -m pip install -r requirements.txt
 ```
 
-Run the install script to generate the files to make the Github Actions work (from the root of your repo):
-
-```bash session
-python -m bench_runner install
-```
-
-This will create some files in `.github/workflows` as well as some configuration files at the root of your repo.
-Commit them to your repository, and push up to Github.
-
-```bash session
-git commit -a -m "Initial commit"
-git push origin main
-```
-
 ### Add some self-hosted runners
 
 Provision the machine to have the build requirements for CPython and the base
@@ -71,6 +57,22 @@ hostname = pyperf
 ```
 
 **TODO**: Describe the special pystats runner
+
+### Generate workflows
+
+Run the install script to generate the files to make the Github Actions work (from the root of your repo):
+
+```bash session
+python -m bench_runner install
+```
+
+This will create some files in `.github/workflows` as well as some configuration files at the root of your repo.
+Commit them to your repository, and push up to Github.
+
+```bash session
+git commit -a -m "Initial commit"
+git push origin main
+```
 
 ### Try a benchmarking run
 

--- a/bench_runner/runners.py
+++ b/bench_runner/runners.py
@@ -68,6 +68,9 @@ def get_runners(path: Path | None = None) -> list[Runner]:
             )
         )
 
+    if len(runners) == 0:
+        raise RuntimeError(f"No runners are defined in `{path}`. Please set up some runners first.")
+
     return runners
 
 

--- a/bench_runner/runners.py
+++ b/bench_runner/runners.py
@@ -68,8 +68,6 @@ def get_runners(path: Path | None = None) -> list[Runner]:
             )
         )
 
-    assert len(runners)
-
     return runners
 
 

--- a/bench_runner/runners.py
+++ b/bench_runner/runners.py
@@ -69,7 +69,9 @@ def get_runners(path: Path | None = None) -> list[Runner]:
         )
 
     if len(runners) == 0:
-        raise RuntimeError(f"No runners are defined in `{path}`. Please set up some runners first.")
+        raise RuntimeError(
+            f"No runners are defined in `{path}`. Please set up some runners first."
+        )
 
     return runners
 


### PR DESCRIPTION
There may be no runners when `bench_runner install` is executed for the first time.

Fixes gh-225.