### PR TITLE
gh-249: Replace azure with cloud in _pystats.yml

### DIFF
--- a/bench_runner/scripts/compare.py
+++ b/bench_runner/scripts/compare.py
@@ -154,8 +154,8 @@ def _main(commits: Sequence[str], output_dir: Path, comparison_type: str):
         else:
             machines &= get_machines(subresults)
 
-    if "azure" in machines:
-        machines.remove("azure")
+    if "cloud" in machines:
+        machines.remove("cloud")
 
     if len(machines) == 0:
         raise ValueError("No single machine in common with all of the results")

--- a/bench_runner/templates/_pystats.src.yml
+++ b/bench_runner/templates/_pystats.src.yml
@@ -45,8 +45,7 @@ name: _pystats
 
 jobs:
   collect-stats:
-    # TODO: Replace "azure" with "cloud"
-    runs-on: [self-hosted, linux, azure]
+    runs-on: [self-hosted, linux, cloud]
     steps:
       - name: Checkout benchmarking
         uses: actions/checkout@v4


### PR DESCRIPTION
In order to run _pystats job with other non-Azure self-hosted machine. 

Fixed https://github.com/faster-cpython/bench_runner/issues/249.