### PR TITLE
Fix #326: Add a checkbox to build with clang

### DIFF
--- a/bench_runner/flags.py
+++ b/bench_runner/flags.py
@@ -17,6 +17,7 @@ FLAGS = [
     Flag("tier2", "PYTHON_UOPS", "tier 2 interpreter", "T2"),
     Flag("jit", "JIT", "JIT", "JIT"),
     Flag("nogil", "NOGIL", "free threading", "NOGIL"),
+    Flag("clang", "CLANG", "build with latest clang", "CLANG"),
 ]
 
 

--- a/bench_runner/templates/_benchmark.src.yml
+++ b/bench_runner/templates/_benchmark.src.yml
@@ -204,7 +204,9 @@ jobs:
       - name: Build with clang
         if: ${{ inputs.clang }}
         run: |
-          echo "CC=clang-19" >> $GITHUB_ENV
+          echo "CC=`which clang-19`" >> $GITHUB_ENV
+          echo "LLVM_AR=`which llvm-ar-19`" >> $GITHUB_ENV
+          echo "LLVM_PROFDATA=`which llvm-profdata-19`" >> $GITHUB_ENV
       - name: Build Python
         if: ${{ steps.should_run.outputs.should_run != 'false' }}
         run: |

--- a/bench_runner/templates/_benchmark.src.yml
+++ b/bench_runner/templates/_benchmark.src.yml
@@ -309,7 +309,7 @@ jobs:
         if: ${{ steps.should_run.outputs.should_run != 'false' }}
         run: |
           echo "PKG_CONFIG_PATH=$(brew --prefix openssl@1.1)/lib/pkgconfig" >> $GITHUB_ENV
-      - name: Setup latest clang, if requested
+      - name: Build with clang
         if: ${{ inputs.clang }}
         run: |
           echo "PATH=$(brew --prefix llvm)/bin:$PATH" >> $GITHUB_ENV

--- a/bench_runner/templates/_benchmark.src.yml
+++ b/bench_runner/templates/_benchmark.src.yml
@@ -48,9 +48,6 @@ name: _benchmark
       benchmarks:
         description: "Benchmarks to run (comma-separated; empty runs all benchmarks)"
         type: string
-      pgo:
-        description: "Build with PGO"
-        type: boolean
       force:
         description: "Rerun and replace results if commit already exists"
         type: boolean

--- a/bench_runner/templates/_benchmark.src.yml
+++ b/bench_runner/templates/_benchmark.src.yml
@@ -109,6 +109,11 @@ jobs:
           repository: mdboom/pyperformance
           path: pyperformance
           ref: ${{ env.PYPERFORMANCE_HASH }}
+      - name: Build with clang
+        if: ${{ inputs.clang }}
+        run: |
+          Write-Error "Using the latest clang compiler on Windows isn't currently supported by bench-runner"
+          exit 1
       - name: Build Python
         if: ${{ steps.should_run.outputs.should_run != 'false' }}
         run: |
@@ -116,6 +121,7 @@ jobs:
           PCbuild\build.bat ($env:BUILD_FLAGS -split ' ') ${{ inputs.pgo == true && '--pgo' || '' }} ${{ inputs.jit == true && '--experimental-jit' || '' }} ${{ inputs.tier2 == true && '--experimental-jit-interpreter' || '' }} ${{ inputs.nogil == true && '--disable-gil' || '' }} -c Release
           # Copy the build products to a place that libraries can find them.
           Copy-Item -Path $env:BUILD_DEST -Destination "libs" -Recurse
+          $env:BUILD_DEST\python.exe -VV
       - name: Install pyperformance
         if: ${{ steps.should_run.outputs.should_run != 'false' }}
         run: |
@@ -198,12 +204,17 @@ jobs:
           repository: mdboom/pyperformance
           path: pyperformance
           ref: ${{ env.PYPERFORMANCE_HASH }}
+      - name: Build with clang
+        if: ${{ inputs.clang }}
+        run: |
+          echo "CC=clang-19" >> $GITHUB_ENV
       - name: Build Python
         if: ${{ steps.should_run.outputs.should_run != 'false' }}
         run: |
           cd cpython
           ./configure ${{ inputs.pgo == true && '--enable-optimizations --with-lto=yes' || '' }} ${{ inputs.tier2 == true && '--enable-experimental-jit=interpreter' || '' }} ${{ inputs.jit == true && '--enable-experimental-jit=yes' || '' }} ${{ inputs.nogil == true && '--disable-gil' || '' }}
           make ${{ runner.arch == 'ARM64' && '-j' || '-j4' }}
+          ./python -VV
       - name: Install pyperformance
         if: ${{ steps.should_run.outputs.should_run != 'false' }}
         run: |
@@ -299,12 +310,20 @@ jobs:
         if: ${{ steps.should_run.outputs.should_run != 'false' }}
         run: |
           echo "PKG_CONFIG_PATH=$(brew --prefix openssl@1.1)/lib/pkgconfig" >> $GITHUB_ENV
+      - name: Setup latest clang, if requested
+        if: ${{ inputs.clang }}
+        run: |
+          echo "PATH=$(brew --prefix llvm)/bin:$PATH" >> $GITHUB_ENV
+          echo "CC=$(brew --prefix llvm)/bin/clang" >> $GITHUB_ENV
+          echo "LDFLAGS=-L$(brew --prefix llvm)/lib" >> $GITHUB_ENV
+          echo "CFLAGS=-I$(brew --prefix llvm)/include" >> $GITHUB_ENV
       - name: Build Python
         if: ${{ steps.should_run.outputs.should_run != 'false' }}
         run: |
           cd cpython
           ./configure ${{ inputs.pgo == true && '--enable-optimizations --with-lto=yes' || '' }} ${{ inputs.tier2 == true && '--enable-experimental-jit=interpreter' || '' }} ${{ inputs.jit == true && '--enable-experimental-jit=yes' || '' }} ${{ inputs.nogil == true && '--disable-gil' || '' }}
           make -j4
+          ./python.exe -VV
       # On macos ARM64, actions/setup-python isn't available, so we rely on a
       # pre-installed homebrew one, used through a venv
       - name: Install pyperformance

--- a/tests/test_gh.py
+++ b/tests/test_gh.py
@@ -58,4 +58,6 @@ def test_benchmark_cmdline(monkeypatch):
         "jit=false",
         "-f",
         "nogil=false",
+        "-f",
+        "clang=false",
     ]


### PR DESCRIPTION
This adds a checkbox to build CPython with "latest" clang, and then will flag the results so we know it's a special configuration.

This only works with macOS and Linux right now.  Windows is possible but I plan to do it as a follow-on since it's a bit more involved.

Cc: @Fidget-Spinner, @brandtbucher 