### PR TITLE
Enable PGO for ClangCl on Windows

### DIFF
--- a/bench_runner/templates/_benchmark.src.yml
+++ b/bench_runner/templates/_benchmark.src.yml
@@ -112,7 +112,7 @@ jobs:
         shell: cmd
         run: |
           cd cpython
-          PCbuild\build.bat %BUILD_FLAGS% ${{ (inputs.pgo == true && inputs.clang != true) && '--pgo' || '' }} ${{ inputs.jit == true && '--experimental-jit' || '' }} ${{ inputs.tier2 == true && '--experimental-jit-interpreter' || '' }} ${{ inputs.nogil == true && '--disable-gil' || '' }} -c Release ${{ inputs.clang == true && '"/p:PlatformToolset=clangcl"' || '' }} ${{ inputs.clang == true && '"/p:LLVMInstallDir=C:\Program Files\LLVM"' || '' }} ${{ inputs.clang == true && '"/p:LLVMToolsVersion=19.1.6"' || '' }}
+          PCbuild\build.bat %BUILD_FLAGS% ${{ (inputs.pgo == true) && '--pgo' || '' }} ${{ inputs.jit == true && '--experimental-jit' || '' }} ${{ inputs.tier2 == true && '--experimental-jit-interpreter' || '' }} ${{ inputs.nogil == true && '--disable-gil' || '' }} -c Release ${{ inputs.clang == true && '"/p:PlatformToolset=clangcl"' || '' }} ${{ inputs.clang == true && '"/p:LLVMInstallDir=C:\Program Files\LLVM"' || '' }} ${{ inputs.clang == true && '"/p:LLVMToolsVersion=19.1.6"' || '' }}
       - name: Copy Python to different location
         if: ${{ steps.should_run.outputs.should_run != 'false' }}
         run: |


### PR DESCRIPTION
Thanks to Chris Eibl, we can enable PGO for the clang-cl builds. This should be a pretty large boost according to Chris.

https://github.com/python/cpython/pull/129907