### PR TITLE
Add support for passing extra flags to Python's configure via env vars

### DIFF
--- a/bench_runner/templates/_benchmark.src.yml
+++ b/bench_runner/templates/_benchmark.src.yml
@@ -211,7 +211,7 @@ jobs:
         if: ${{ steps.should_run.outputs.should_run != 'false' }}
         run: |
           cd cpython
-          ./configure ${{ inputs.pgo == true && '--enable-optimizations --with-lto=full' || '' }} ${{ inputs.tier2 == true && '--enable-experimental-jit=interpreter' || '' }} ${{ inputs.jit == true && '--enable-experimental-jit=yes' || '' }} ${{ inputs.nogil == true && '--disable-gil' || '' }} ${{ inputs.clang == true && '--with-tail-call-interp' || '' }}
+          ./configure ${{ inputs.pgo == true && '--enable-optimizations --with-lto=full' || '' }} ${{ inputs.tier2 == true && '--enable-experimental-jit=interpreter' || '' }} ${{ inputs.jit == true && '--enable-experimental-jit=yes' || '' }} ${{ inputs.nogil == true && '--disable-gil' || '' }} ${{ inputs.clang == true && '--with-tail-call-interp' || '' }} ${PYTHON_CONFIGURE_FLAGS:-}
           make ${{ runner.arch == 'ARM64' && '-j' || '-j4' }}
           ./python -VV
       - name: Install pyperformance
@@ -321,7 +321,7 @@ jobs:
         if: ${{ steps.should_run.outputs.should_run != 'false' }}
         run: |
           cd cpython
-          ./configure ${{ inputs.pgo == true && '--enable-optimizations --with-lto=full' || '' }} ${{ inputs.tier2 == true && '--enable-experimental-jit=interpreter' || '' }} ${{ inputs.jit == true && '--enable-experimental-jit=yes' || '' }} ${{ inputs.nogil == true && '--disable-gil' || '' }} ${{ inputs.clang == true && '--with-tail-call-interp' || '' }}
+          ./configure ${{ inputs.pgo == true && '--enable-optimizations --with-lto=full' || '' }} ${{ inputs.tier2 == true && '--enable-experimental-jit=interpreter' || '' }} ${{ inputs.jit == true && '--enable-experimental-jit=yes' || '' }} ${{ inputs.nogil == true && '--disable-gil' || '' }} ${{ inputs.clang == true && '--with-tail-call-interp' || '' }} ${PYTHON_CONFIGURE_FLAGS:-}
           make -j4
           ./python.exe -VV
       # On macos ARM64, actions/setup-python isn't available, so we rely on a

--- a/bench_runner/templates/bench_runner.toml
+++ b/bench_runner/templates/bench_runner.toml
@@ -24,7 +24,24 @@ notification_issue = 182
 #   socket.gethostname()).
 # available: True if the machine is available (we need to keep the
 #   metadata around for old machines for the generated results). (Default: True)
-
+# include_in_all: Whether to include the runner when choosing to run a
+#   benchmark on all runners.
+# env: a table of extra environment variables to pass to the runs.
+#
+# A few notable environment variables for runners:
+# CC, CXX: used by Python's configure to determine the compiler to use.
+# LLVM_AR, LLVM_PROFDATA: used for PGO optimization passes with clang, when
+#   using a version of clang that isn't the default. These must be full
+#   paths for configure to handle them correctly.
+# LLVM_BOLT, MERGE_FDATA: like AR/PROFDATA, but for BOLT.
+#   LLVM_BOLT may need to point to, e.g., /usr/lib/llvm-19/bin/llvm-bolt
+#   rather than /usr/bin/llvm-bolt-19 (see
+#   https://github.com/python/cpython/issues/127047).
+# PYTHON_CONFIGURE_FLAGS: extra flags to pass to Python's configure. These
+#   can override all earlier flags, which by default include
+#   --enable-optimizations and --with-lto=full.
+# BUILD_DEST: (windows only) where to make build.bat install. This is
+#   required for the Windows build to succeed.
 [[runners]]
 
 [runners.linux]
@@ -32,6 +49,13 @@ os = "linux"
 arch = "x86_64"
 hostname = "pyperf"
 available = true
+
+[runners.windows]
+os = "windows"
+arch = "x86_64"
+hostname = "winperf"
+available = true
+env.BUILD_DEST = "PCbuild/amd64"
 
 [plot]
 bases = ["3.11.0"]


### PR DESCRIPTION
Add support for passing extra flags to Python's configure via env vars, which can override earlier passed flags (like --enable-optimizations).

Add a description of env vars to the sample bench_runner.toml, describe a few common pitfalls with a few specific ones, and include a windows runner to show BUILD_DEST being set.
