### PR TITLE
Add support for explicit per-runner CPU affinity

### DIFF
--- a/bench_runner/scripts/run_benchmarks.py
+++ b/bench_runner/scripts/run_benchmarks.py
@@ -82,8 +82,8 @@ def run_benchmarks(
     if extra_args is None:
         extra_args = []
 
-    if (affinity := os.environ.get('CPU_AFFINITY')):
-        extra_args.append(f'--affinity={affinity}')
+    if affinity := os.environ.get("CPU_AFFINITY"):
+        extra_args.append(f"--affinity={affinity}")
 
     args = [
         sys.executable,

--- a/bench_runner/scripts/run_benchmarks.py
+++ b/bench_runner/scripts/run_benchmarks.py
@@ -82,6 +82,9 @@ def run_benchmarks(
     if extra_args is None:
         extra_args = []
 
+    if (affinity := os.environ.get('CPU_AFFINITY')):
+        extra_args.append(f'--affinity={affinity}')
+
     args = [
         sys.executable,
         "-m",

--- a/bench_runner/scripts/run_benchmarks.py
+++ b/bench_runner/scripts/run_benchmarks.py
@@ -66,7 +66,7 @@ def run_benchmarks(
     benchmarks: str,
     /,
     test_mode: bool = False,
-    extra_args: Iterable[str] | None = None,
+    extra_args: list[str] | None = None,
 ) -> None:
     if benchmarks.strip() == "":
         benchmarks = "all"

--- a/bench_runner/templates/_benchmark.src.yml
+++ b/bench_runner/templates/_benchmark.src.yml
@@ -221,7 +221,7 @@ jobs:
       - name: Tune system
         if: ${{ steps.should_run.outputs.should_run != 'false' }}
         run: |
-          sudo LD_LIBRARY_PATH=$LD_LIBRARY_PATH venv/bin/python -m pyperf system ${{ inputs.perf && 'reset' || 'tune ${PYPERF_CPU_AFFINITY:+--affinity="$PYPERF_CPU_AFFINITY"}' }}
+          sudo LD_LIBRARY_PATH=$LD_LIBRARY_PATH venv/bin/python -m pyperf system ${{ inputs.perf && 'reset' || 'tune ${CPU_AFFINITY:+--affinity="$CPU_AFFINITY"}' }}
       - name: Tune for (Linux) perf
         if: ${{ steps.should_run.outputs.should_run != 'false' && inputs.perf }}
         run: |

--- a/bench_runner/templates/_benchmark.src.yml
+++ b/bench_runner/templates/_benchmark.src.yml
@@ -221,7 +221,7 @@ jobs:
       - name: Tune system
         if: ${{ steps.should_run.outputs.should_run != 'false' }}
         run: |
-          sudo LD_LIBRARY_PATH=$LD_LIBRARY_PATH venv/bin/python -m pyperf system ${{ inputs.perf && 'reset' || 'tune' }}
+          sudo LD_LIBRARY_PATH=$LD_LIBRARY_PATH venv/bin/python -m pyperf system ${{ inputs.perf && 'reset' || 'tune ${PYPERF_CPU_AFFINITY:+--affinity="$PYPERF_CPU_AFFINITY"}' }}
       - name: Tune for (Linux) perf
         if: ${{ steps.should_run.outputs.should_run != 'false' && inputs.perf }}
         run: |
@@ -232,6 +232,10 @@ jobs:
         run: |
           rm -rf ~/.debug/*
           venv/bin/python -m bench_runner run_benchmarks ${{ inputs.perf && 'perf' || 'benchmark' }} cpython/python ${{ inputs.fork }} ${{ inputs.ref }} ${{ inputs.benchmarks || 'all' }} ${{ env.flags }} --run_id ${{ github.run_id }}
+      - name: Untune system
+        if: ${{ steps.should_run.outputs.should_run != 'false' }}
+        run: |
+          sudo LD_LIBRARY_PATH=$LD_LIBRARY_PATH venv/bin/python -m pyperf system reset
       # Pull again, since another job may have committed results in the meantime
       - name: Pull benchmarking
         if: ${{ steps.should_run.outputs.should_run != 'false' && !inputs.perf }}


### PR DESCRIPTION
Add support for explicit CPU affinity via a runner-configurable environment variable (either in the runner configuration, or in the environment of the GHA runner itself). This is useful when running on a host that can't use isolated CPUs (which pyperf automatically detects).

Also undo the changes made by `pyperf system tune` after the benchmark run. (The system is generally more performant without benchmark tuning, so this matters for other users of the host and for the compile time on a dedicated runner.)
