### PR TITLE
Remove the actions/setup-python action for self-hosted Linux runners.

### DIFF
--- a/PROVISIONING.md
+++ b/PROVISIONING.md
@@ -19,6 +19,8 @@ sudo apt install python3 build-essential ccache gdb lcov pkg-config \
       lzma lzma-dev tk-dev uuid-dev zlib1g-dev linux-perf
 ```
 
+The self-hosted runner needs to have `python` be Python 3.9 or later.
+
 ### Enable ccache
 
 ```bash session

--- a/bench_runner/templates/_benchmark.src.yml
+++ b/bench_runner/templates/_benchmark.src.yml
@@ -161,11 +161,6 @@ jobs:
         run: |
           git gc
       - uses: fregante/setup-git-user@v2
-      - name: Setup system Python
-        if: ${{ runner.arch == 'X64' }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
       - name: Checkout CPython
         uses: actions/checkout@v4
         with:
@@ -324,8 +319,6 @@ jobs:
           ./configure ${{ inputs.pgo == true && '--enable-optimizations --with-lto=full' || '' }} ${{ inputs.tier2 == true && '--enable-experimental-jit=interpreter' || '' }} ${{ inputs.jit == true && '--enable-experimental-jit=yes' || '' }} ${{ inputs.nogil == true && '--disable-gil' || '' }} ${{ inputs.clang == true && '--with-tail-call-interp' || '' }}
           make -j4
           ./python.exe -VV
-      # On macos ARM64, actions/setup-python isn't available, so we rely on a
-      # pre-installed homebrew one, used through a venv
       - name: Install pyperformance
         if: ${{ steps.should_run.outputs.should_run != 'false' }}
         run: |


### PR DESCRIPTION
Remove the actions/setup-python action for self-hosted Linux runners (since the action only really supports GitHub runners). Document this requirement in PROVISIONING.md.
