### PR TITLE
Avoid cross-filesystem renames in svg generation

### DIFF
--- a/bench_runner/plot.py
+++ b/bench_runner/plot.py
@@ -65,7 +65,7 @@ def savefig(output_filename: PathLike, **kwargs):
     plt.close("all")
 
     if output_filename.suffix == ".svg":
-        with tempfile.NamedTemporaryFile(delete=False) as tmp:
+        with tempfile.NamedTemporaryFile(dir=output_filename.parent, delete=False) as tmp:
             with open(output_filename) as fd:
                 scour.start(Options(), fd, tmp)
             output_filename.unlink()

--- a/bench_runner/plot.py
+++ b/bench_runner/plot.py
@@ -65,7 +65,9 @@ def savefig(output_filename: PathLike, **kwargs):
     plt.close("all")
 
     if output_filename.suffix == ".svg":
-        with tempfile.NamedTemporaryFile(dir=output_filename.parent, delete=False) as tmp:
+        with tempfile.NamedTemporaryFile(
+            dir=output_filename.parent, delete=False
+        ) as tmp:
             with open(output_filename) as fd:
                 scour.start(Options(), fd, tmp)
             output_filename.unlink()


### PR DESCRIPTION
In svg generation, make temporary files in the output directory, to avoid cross-filesystem renames if /tmp is a different filesystem.