### PR TITLE
Don't try to send notifications to GitHub when the issue is 0.

### DIFF
--- a/bench_runner/gh.py
+++ b/bench_runner/gh.py
@@ -73,6 +73,10 @@ def benchmark(
 def send_notification(body):
     conf = config.get_bench_runner_config()
     notification_issue = conf.get("notify", {}).get("notification_issue", 0)
+    
+    if notification_issue == 0:
+        print("Not sending Github notification.")
+        return
 
     print("Sending Github notification:")
     print("---")


### PR DESCRIPTION
(It would probably make sense to skip this part of the workflow altogether if the config doesn't set the issue number, but this is the easier fix.)