### PR TITLE
Make loops.json files per-runner-configurable

### DIFF
--- a/bench_runner/scripts/run_benchmarks.py
+++ b/bench_runner/scripts/run_benchmarks.py
@@ -34,6 +34,7 @@ GITHUB_URL = "https://github.com/" + os.environ.get(
 )
 # Environment variables that control the execution of CPython
 ENV_VARS = ["PYTHON_JIT", "PYPERF_PERF_RECORD_EXTRA_OPTS"]
+LOOPS_FILE_ENV_VAR = "PYPERFORMANCE_LOOPS_FILE"
 
 
 class NoBenchmarkError(Exception):
@@ -81,6 +82,10 @@ def run_benchmarks(
 
     if extra_args is None:
         extra_args = []
+
+    if (loops_file := os.environ.get(LOOPS_FILE_ENV_VAR)):
+        extra_args.append("--same-loops")
+        extra_args.append(loops_file)
 
     args = [
         sys.executable,
@@ -130,7 +135,12 @@ def collect_pystats(
 
     all_benchmarks = get_benchmark_names(benchmarks)
 
-    extra_args = ["--same-loops", "loops.json", "--hook", "pystats"]
+    # Default to loops.json if not explicitly set, like before the
+    # environment variable was added.
+    if LOOPS_FILE_ENV_VAR not in os.environ:
+        os.environ[LOOPS_FILE_ENV_VAR] = "loops.json"
+
+    extra_args = ["--hook", "pystats"]
 
     if flags is None:
         flags = []

--- a/bench_runner/scripts/run_benchmarks.py
+++ b/bench_runner/scripts/run_benchmarks.py
@@ -83,7 +83,7 @@ def run_benchmarks(
     if extra_args is None:
         extra_args = []
 
-    if (loops_file := os.environ.get(LOOPS_FILE_ENV_VAR)):
+    if loops_file := os.environ.get(LOOPS_FILE_ENV_VAR):
         extra_args.append("--same-loops")
         extra_args.append(loops_file)
 

--- a/bench_runner/scripts/run_benchmarks.py
+++ b/bench_runner/scripts/run_benchmarks.py
@@ -86,7 +86,7 @@ def run_benchmarks(
     if loops_file := os.environ.get(LOOPS_FILE_ENV_VAR):
         extra_args.append("--same-loops")
         extra_args.append(loops_file)
-        
+
     if affinity := os.environ.get("CPU_AFFINITY"):
         extra_args.append(f"--affinity={affinity}")
 

--- a/bench_runner/scripts/run_benchmarks.py
+++ b/bench_runner/scripts/run_benchmarks.py
@@ -67,7 +67,7 @@ def run_benchmarks(
     benchmarks: str,
     /,
     test_mode: bool = False,
-    extra_args: Iterable[str] | None = None,
+    extra_args: list[str] | None = None,
 ) -> None:
     if benchmarks.strip() == "":
         benchmarks = "all"


### PR DESCRIPTION
Add support for passing --same-loops to pyperformance for regular runs (not just pystats) by setting the PYPERFORMANCE_LOOPS_FILE environment variable.

Specifying a reasonable number of loops for each runner makes my A-A tests go from ~2% variability down to ~0.5%.