### PR TITLE
Remove dependency on tomli

### DIFF
--- a/bench_runner/config.py
+++ b/bench_runner/config.py
@@ -4,12 +4,8 @@ Handles the loading of the bench_runner.toml configuration file.
 
 import functools
 from pathlib import Path
+import tomllib
 from typing import Any
-
-try:
-    import tomllib
-except ImportError:
-    import tomli as tomllib  # type: ignore
 
 
 from . import runners

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ dependencies = [
     "rich-argparse==1.7.0",
     "ruamel.yaml==0.18.10",
     "scour==0.38.2",
-    "tomli==2.0.1",
     "wheel",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
Since we require 3.11 or later now, this dependency is no longer needed.