### PR TITLE
Add machine to run name

### DIFF
--- a/bench_runner/templates/benchmark.src.yml
+++ b/bench_runner/templates/benchmark.src.yml
@@ -1,6 +1,6 @@
 ---
 name: benchmark
-run-name: benchmarking ${{ inputs.fork }}/${{ inputs.ref }}
+run-name: benchmarking ${{ inputs.fork }}/${{ inputs.ref }} on ${{ inputs.machine }}
 
 "on":
   workflow_dispatch:


### PR DESCRIPTION
This adds the selected runner in the workflow run name (or 'all' or '__really_all', if that's what they were scheduled on), which makes the workflow overview a lot more tenable if you have multiple runners.

The runner name currently gets added after the ref and before any flags for the run. I'm not sure which is more readable, but I think this probably makes most sense: the flags are not a property of the fork/ref, and though they're not a property of the runner either, it's more similar to that.

![image](https://github.com/user-attachments/assets/29028d1a-a90f-47a8-852a-e3903e625365)
