### PR TITLE
Use `py` instead of `python` on Windows

### DIFF
--- a/bench_runner/templates/_benchmark.src.yml
+++ b/bench_runner/templates/_benchmark.src.yml
@@ -73,7 +73,7 @@ jobs:
           git gc
       - name: Building Python and running pyperformance
         run: |
-          python workflow_bootstrap.py ${{ inputs.fork }} ${{ inputs.ref }} ${{ inputs.machine }} ${{ inputs.benchmarks || 'all' }} "${{ env.flags }}" ${{ inputs.force && '--force' || '' }} ${{ inputs.pgo && '--pgo' || '' }} --run_id ${{ github.run_id }}
+          py workflow_bootstrap.py ${{ inputs.fork }} ${{ inputs.ref }} ${{ inputs.machine }} ${{ inputs.benchmarks || 'all' }} "${{ env.flags }}" ${{ inputs.force && '--force' || '' }} ${{ inputs.pgo && '--pgo' || '' }} --run_id ${{ github.run_id }}
       # Pull again, since another job may have committed results in the meantime
       - name: Pull benchmarking
         run: |


### PR DESCRIPTION
On my Windows runner, which has Python installs downloaded from python.org, `python` tries to open the Windows app store, which fails in amusing ways from the GHA runner. `py` seems to work just fine, though.