### PR TITLE
Fix longitudinal plots using the wrong base

### DIFF
--- a/bench_runner/plot.py
+++ b/bench_runner/plot.py
@@ -298,7 +298,7 @@ def longitudinal_plot(
                 runner_results = [r for r in runner_results if r.flags == []]
 
             for r in results:
-                if r.nickname == runner and r.version == base:
+                if r.nickname == runner and r.version == base and r.flags == []:
                     ref = r
                     break
             else:


### PR DESCRIPTION
In the generation of longitudinal plots, when finding the base comparison to compare against, use results without flags rather than whatever happens to be found first.
