### PR TITLE
Fix longitudinal plots with a single comparison version.

### DIFF
--- a/bench_runner/plot.py
+++ b/bench_runner/plot.py
@@ -260,12 +260,17 @@ def longitudinal_plot(
 
     axs: Sequence[matplotlib.Axes]  # pyright: ignore
 
+    numvers = len(cfg["versions"])
+
     fig, axs = plt.subplots(
-        len(cfg["versions"]),
+        numvers,
         1,
-        figsize=(10, 5 * len(cfg["versions"])),
+        figsize=(10, 5 * numvers),
         layout="constrained",
     )  # type: ignore
+    
+    if numvers == 1:
+        axs = [axs]
 
     results = [r for r in results if r.fork == "python"]
 

--- a/bench_runner/plot.py
+++ b/bench_runner/plot.py
@@ -268,7 +268,7 @@ def longitudinal_plot(
         figsize=(10, 5 * numvers),
         layout="constrained",
     )  # type: ignore
-    
+
     if numvers == 1:
         axs = [axs]
 


### PR DESCRIPTION
If there's a single subplot, pyplot.subplots's second return value is not an array, so we can't zip() it.

There is at least one hard-coded assumption about the longitudinal plots (specifically, that the third plot is for JIT) but while that's probably a bit confusing if you'd want to have three plots for different versions, at least it appears clearly in the output label. (I've been thinking about ways to make the plotting more configurable, but in the mean time this fixes a bug when you only care about one longitudinal plot.)