### PR TITLE
Make flag effect plots with runner_map work

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ The flag effect plot shows the effect of specified configuration flags against a
 In `bench_runner.toml`, the `flag_effect_plot` table has a `subplots` key which is an array of tables with the following keys:
 
 - `name`: The description of the flags to use in the title.
+- `version`: The version series to compare. Should be a 2-part version, e.g. "3.14"
 - `head_flags`: A list of flags to use as the head.
 - `base_flags`: (optional) A list of flags to use as the base. By default, this is a default build, i.e. no flags.
 - `runner_map`: (optional) If you need to map a runner to a base in a different runner, you can provide that mapping here. For example, with tail-calling, you may want to compare runners configured to use clang against runners configured with the "default compiler" for a given platform. The mapping is from the "head" runner nickname to the "base" runner nickname.
@@ -178,10 +179,12 @@ For example:
 ```toml
 [[flag_effect_plot.subplots]]
 name = "JIT"
+version = "3.14"
 head_flags = ["JIT"]
 
 [[flag_effect_plot.subplots]]
 name = "Tail calling interpreter"
+version = "3.14"
 head_flags = ["TAILCALL"]
 runner_map = { linux_clang = "linux" }
 ```


### PR DESCRIPTION
Make flag effect plots with runner_map work:
 - When using a runner_map, force benchmark comparisons to be valid, since results from a different runner would otherwise not count.
 - Add version to flag effect plots so we don't end up comparing e.g. v3.14.0a7 and v3.13.10, which were created 15 minutes apart but do not make sense to compare even with a runner_map.
 - If a runner_map is used, don't plot runners that aren't listed in the runner_map.
