### PR TITLE
Add a by-benchmark longitudinal plot

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ The benchmark longitudinal plot shows the change over time, per benchmark. The c
 
 - `base`: The base version
 - `version`: The version to track
-- `runner`: The runner to use
+- `runners`: The runners to show
 - `head_flags`: (optional) The flags to use for the head commits
 - `base_flags`: (optional) The flags to use for the base commits
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ For each runner in your `bench_runner.toml`, you can specify a `plot` table with
 - `marker`: A [matplotlib marker](https://matplotlib.org/stable/api/markers_api.html#module-matplotlib.markers)
 - `color`: A [matplotlib color](https://matplotlib.org/stable/users/explain/colors/colors.html#colors-def)
 
-#### Longitudinal plot configuration
+##### Longitudinal plot configuration
 
 The longitudinal plot shows the change of a version branch over time against a specified base version. It is made up of multiple subplots, each with its own head and base, and optionally configuration flags.
 
@@ -162,7 +162,7 @@ subplots = [
 ]
 ```
 
-#### Flag effect plot configuration
+##### Flag effect plot configuration
 
 The flag effect plot shows the effect of specified configuration flags against a base with the same commit hash, but different configuration flags.
 
@@ -185,6 +185,16 @@ name = "Tail calling interpreter"
 head_flags = ["TAILCALL"]
 runner_map = { linux_clang = "linux" }
 ```
+
+##### Benchmark longitudinal plot configuration
+
+The benchmark longitudinal plot shows the change over time, per benchmark. The configuration consists of the following keys:
+
+- `base`: The base version
+- `version`: The version to track
+- `runner`: The runner to use
+- `head_flags`: (optional) The flags to use for the head commits
+- `base_flags`: (optional) The flags to use for the base commits
 
 #### Purging old data
 

--- a/bench_runner/plot.py
+++ b/bench_runner/plot.py
@@ -534,6 +534,9 @@ def flag_effect_plot(
 def benchmark_longitudinal_plot(
     results: Iterable[result.Result], output_filename: PathLike
 ):
+    if "benchmark_longitudinal_plot" not in mconfig.get_bench_runner_config():
+        return
+
     output_filename = Path(output_filename)
 
     cache_filename = output_filename.with_suffix(".json")

--- a/bench_runner/plot.py
+++ b/bench_runner/plot.py
@@ -571,7 +571,8 @@ def benchmark_longitudinal_plot(
             timing = comparison.get_timing_diff()
 
             for name, _diff, mean in timing:
-                if mean > 0.01:
+                # Don't include insignificant results
+                if mean > 0.0:
                     value = [r.commit_date, mean, r.cpython_hash]
                     if r.filename.name not in cache:
                         cache[r.filename.name] = {}

--- a/bench_runner/scripts/generate_results.py
+++ b/bench_runner/scripts/generate_results.py
@@ -419,6 +419,11 @@ def _main(repo_dir: PathLike, force: bool = False, bases: Sequence[str] | None =
                     title="Memory usage change by configuration",
                 ),
             ),
+            (
+                plot.benchmark_longitudinal_plot,
+                (benchmarking_results, repo_dir / "benchmarks.svg"),
+                {},
+            ),
         ],
         "Generating plots",
     ):

--- a/bench_runner/templates/README.md
+++ b/bench_runner/templates/README.md
@@ -9,6 +9,7 @@ Here are some recent and important revisions. 👉 [Complete list of results](RE
 [Currently failing benchmarks](failures.md).
 
 **Key:** 📄: table, 📈: time plot, 🧠: memory plot
+
 <!-- START table -->
 
 <!-- END table -->
@@ -26,6 +27,8 @@ Improvement of the geometric mean of key merged benchmarks, computed with `pyper
 The results have a resolution of 0.01 (1%).
 
 ![Configuration speed improvement](/configs.svg)
+
+There is also a [longitudinal plot by benchmark](/benchmarks.svg).
 
 ## Documentation
 

--- a/tests/data/bench_runner.toml
+++ b/tests/data/bench_runner.toml
@@ -24,7 +24,7 @@ subplots = [
 [benchmark_longitudinal_plot]
 base = "3.10.4"
 version = "3.11"
-runner = "linux"
+runners = ["linux"]
 
 [publish_mirror]
 skip = false

--- a/tests/data/bench_runner.toml
+++ b/tests/data/bench_runner.toml
@@ -21,6 +21,11 @@ subplots = [
     { name = "JIT", head_flags = ["JIT"] },
 ]
 
+[benchmark_longitudinal_plot]
+base = "3.10.4"
+version = "3.11"
+runner = "linux"
+
 [publish_mirror]
 skip = false
 


### PR DESCRIPTION
This produces by-benchmark longitudinal plots, for example:

<details>
<summary>Plot by benchmark</summary>

![benchmarks](https://github.com/user-attachments/assets/2fc96f62-0665-4cf4-a044-c0c23ae2185d)


</details>