### PR TITLE
Fix logging groups for GitHub output so they collapse correctly.

### DIFF
--- a/bench_runner/templates/workflow_bootstrap.src.py
+++ b/bench_runner/templates/workflow_bootstrap.src.py
@@ -59,12 +59,12 @@ def install_requirements(venv: Path) -> None:
 
 def main():
     venv = Path("venv")
-    print("::group::Creating venv")
+    print("::group::Creating venv", file=sys.stderr)
     create_venv(venv)
-    print("::endgroup::")
-    print("::group::Installing requirements")
+    print("::endgroup::", file=sys.stderr)
+    print("::group::Installing requirements", file=sys.stderr)
     install_requirements(venv)
-    print("::endgroup::")
+    print("::endgroup::", file=sys.stderr)
 
     # Now that we've installed the full bench_runner library,
     # continue on in a new process...

--- a/bench_runner/util.py
+++ b/bench_runner/util.py
@@ -91,11 +91,11 @@ if os.getenv("GITHUB_ACTIONS") == "true":
 
     @contextlib.contextmanager
     def log_group(text: str) -> Iterator:
-        print(f"::group::{text}")
+        print(f"::group::{text}", file=sys.stderr)
         try:
             yield
         finally:
-            print("::endgroup::")
+            print("::endgroup::", file=sys.stderr)
 
     def track(iterable: Iterable, name: str) -> Iterable:
         with log_group(name):


### PR DESCRIPTION
I believe this is necessary for the "log groups" to show up right in GitHub's logs. (At least, the output was all messed up in my logs until I applied these changes.)