### PR TITLE
Use a clearer name for longitudinal plots with flags

### DIFF
--- a/bench_runner/plot.py
+++ b/bench_runner/plot.py
@@ -330,9 +330,11 @@ def longitudinal_plot(
             r for r in results if list(r.parsed_version.release[0:2]) == version
         ]
 
-        subtitle = f"Python {cfg['version']}.x vs. {cfg['base']}"
         if len(cfg["flags"]):
-            subtitle += f" ({','.join(cfg['flags'])})"
+            titleflags = f" ({','.join(cfg['flags'])})"
+        else:
+            titleflags = ""
+        subtitle = f"Python {cfg['version']}.x{titleflags} vs. {cfg['base']}"
         ax.set_title(subtitle)
 
         first_runner = True


### PR DESCRIPTION
Make it more obvious from the titles of longitudinal plots with flags that the flag only applies to the head version, not the base version. This changes the title from:
`Python 3.14.x vs. 3.13.0 (NOGIL)`
to:
`Python 3.14.x (NOGIL) vs. 3.13.0`

(I kept wondering why 3.14.x was the same speed as 3.13 for free-threaded Python, when in fact _free-threaded_ 3.14 is the same speed as _regular_ 3.13 😂 )
