### PR TITLE
"--pgo" and "-c Release" are mutually exclusive

### DIFF
--- a/bench_runner/scripts/workflow.py
+++ b/bench_runner/scripts/workflow.py
@@ -185,9 +185,10 @@ def compile_windows(
     args = ["--%"]  # This is the PowerShell "stop parsing" flag
     if force_32bit:
         args.extend(["-p", "win32"])
-    args.extend(["-c", "Release"])
     if pgo:
         args.append("--pgo")
+    else:
+        args.extend(["-c", "Release"])
     if "JIT" in flags:
         args.append("--experimental-jit")
     if "PYTHON_UOPS" in flags:


### PR DESCRIPTION
`--pgo` will just happily ignore `-c Relase`, but let's fix it?

cc @savannahostrowski, since we've just stumbled over it.