### PR TITLE
Fix CPU_AFFINITY flag

### DIFF
--- a/bench_runner/scripts/workflow.py
+++ b/bench_runner/scripts/workflow.py
@@ -226,7 +226,7 @@ def tune_system(venv: PathLike, perf: bool) -> None:
 
     args = ["system", perf and "reset" or "tune"]
     if cpu_affinity := os.environ.get("CPU_AFFINITY"):
-        args.append(f'--affinity="{cpu_affinity}"')
+        args.append(f"--affinity={cpu_affinity}")
 
     run_in_venv(venv, "pyperf", args, sudo=True)
 


### PR DESCRIPTION
This is really an escape string bug.

you can see it is working here: https://github.com/diegorusso/pyperf-bench/actions/runs/24757827257/job/72434698676

```
Perf event: Max sample rate set to 1 per second
  CPU Frequency: Minimum frequency of CPU 175-191 set to the maximum frequency
  IRQ affinity: Set default affinity to CPU 0-174
  IRQ affinity: Set affinity of IRQ 13-15,26-31,39-62,64-71,77,85-86,345-440 to CPU 0-174
  CPU scaling governor: CPU scaling governor of CPUs 175-191 set to performance
```

Earlier instead it was failing in tuning the system when cpu affinity was set

https://github.com/diegorusso/pyperf-bench/actions/runs/24646323352/job/72059601480 the tuning system fails:

```
Tuning system
  usage: -m pyperf system [-h] [--affinity CPU_LIST] [{show,tune,reset}]
  -m pyperf system: error: argument --affinity: invalid CPU list: '"183-191"'
```

